### PR TITLE
removes (in my opinion) unnecessary try/catch block

### DIFF
--- a/challenge.js
+++ b/challenge.js
@@ -2,7 +2,10 @@ const https = require('https')
 
 const makePokeUrl = pokemon => `https://pokeapi.co/api/v2/pokemon/${pokemon}/`
 const pikaUrl = makePokeUrl('pikachu')
+const bulbasaurUrl = makePokeUrl('bulbasaur')
+const charmanderUrl = makePokeUrl('charmander')
 
+// API CALL TO POKEMON
 const myApiCall = (url, callback) => {
   https
     .get(url, resp => {
@@ -11,11 +14,7 @@ const myApiCall = (url, callback) => {
         data += chunk
       })
       resp.on('end', () => {
-        try {
           callback(null, JSON.parse(data))
-        } catch (e) {
-          callback('Oops, this isn\'t JSON')
-        }
       })
     })
     .on('error', err => {
@@ -23,13 +22,12 @@ const myApiCall = (url, callback) => {
     })
 }
 
+// API CALL INVOCATION
 myApiCall(pikaUrl, (err, res) => {
   if (err) console.log(res)
   else console.log(res)
 })
 
 //Now let's make it a Promise
-
-// const myPromiseApi =
 
 //And call it here...

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "mc-promise-me-this",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/solution.js
+++ b/solution.js
@@ -13,11 +13,7 @@ const myPromiseApi = url => {
           data += chunk
         })
         resp.on('end', () => {
-          try {
             resolve(JSON.parse(data))
-          } catch (e) {
-            reject('It dun broked')
-          }
         })
       })
       .on('error', err => {


### PR DESCRIPTION
Gaza cohorts are often confused by the presence of the try/catch block and would try to replace it with a catch/reject

I think it hurts more than it helps to keep it and explain two different error handling scenarios (api error with the promise and json parse error with the try/catch)

It is best in my opinion to focus solely on the promise part of the workshop.